### PR TITLE
Fix VirtualBox downgrade

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -59,10 +59,10 @@ jobs:
                     apt-get update --error-on=any
                     ## Installer aborts if package upgrades are pending.
                     apt-get dist-upgrade --yes
-                    apt-get install --yes shellcheck sudo adduser tor locales curl
+                    apt-get install --yes shellcheck sudo adduser tor locales
                   elif command -v dnf; then
                     dnf upgrade --assumeyes
-                    dnf install --assumeyes ShellCheck sudo tor systemd curl
+                    dnf install --assumeyes ShellCheck sudo tor systemd
                     ## Debugging.
                     dnf provides needs-restarting
                   else
@@ -75,15 +75,36 @@ jobs:
             - name: System information
               run: |
                   cat /etc/os-release
+                  sep="--------------------"
+                  printf '%s\n' "${sep}"
                   uname -a
+                  printf '%s\n' "${sep}"
                   echo "${PATH}"
+                  printf '%s\n' "${sep}"
                   localedef --list-archive
+                  printf '%s\n' "${sep}"
                   locale
+                  printf '%s\n' "${sep}"
+                  if command -v apt-get >/dev/null; then
+                    for f in \
+                      /etc/apt/sources.list \
+                      /etc/apt/sources.list.d/*.list \
+                      /etc/apt/sources.list.d/*.sources
+                    do
+                      test -f "${f}" || continue
+                      printf '%s\n%s\n%s\n' "### ${f} ###" "$(cat "$f")" "${sep}"
+                    done
+                  elif command -v dnf >/dev/null; then
+                    for f in \
+                      /etc/yum.repos.d/*.repo
+                    do
+                      test -f "${f}" || continue
+                      printf '%s\n%s\n%s\n' "### ${f} ###" "$(cat "$f")" "${sep}"
+                    done
+                  fi
+                  printf '%s\n' "${sep}"
                   #cat /etc/sudoers
                   #ls /etc/sudoers.d
-            - name: Test Curl
-              run: |
-                  timeout --foreground 20 curl -vvvv --max-filesize 200K https://www.whonix.org
             - name: Enable Services
               run: |
                   if command -v apt-get; then

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -33,22 +33,19 @@ jobs:
         ## Github takes too long to set the current latest image, this is
         ## why we set it manually.
         ##  https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         strategy:
             fail-fast: false
             matrix:
                 include:
-                    - image: fedora:38
-                    ## https://download.virtualbox.org/virtualbox/rpm/fedora/ no longer has fedora39.
-                    ## Fedora 39 not in VirtualBox Fedora Repository
-                    ## https://www.virtualbox.org//ticket/21929
-                    #- image: fedora:latest
+                    - image: fedora:latest
+                    - image: fedora:rawhide
                     - image: debian:oldstable
                     - image: debian:stable
                     - image: debian:testing
                     - image: debian:unstable
                     - image: ubuntu:latest
-                    - image: linuxmintd/mint21.3-amd64:latest
+                    - image: linuxmintd/mint22.1-amd64:latest
                     - image: kalilinux/kali-rolling
 
         container:
@@ -62,12 +59,12 @@ jobs:
                     apt-get update --error-on=any
                     ## Installer aborts if package upgrades are pending.
                     apt-get dist-upgrade --yes
-                    apt-get install --yes shellcheck sudo adduser tor locales
+                    apt-get install --yes shellcheck sudo adduser tor locales curl
                   elif command -v dnf; then
                     dnf upgrade --assumeyes
-                    dnf install --assumeyes ShellCheck sudo tor systemd
+                    dnf install --assumeyes ShellCheck sudo tor systemd curl
                     ## Debugging.
-                    dnf whatprovides needs-restarting
+                    dnf provides needs-restarting
                   else
                     exit 1
                   fi
@@ -84,6 +81,9 @@ jobs:
                   locale
                   #cat /etc/sudoers
                   #ls /etc/sudoers.d
+            - name: Test Curl
+              run: |
+                  timeout --foreground 20 curl -vvvv --max-filesize 200K https://www.whonix.org
             - name: Enable Services
               run: |
                   if command -v apt-get; then
@@ -148,12 +148,21 @@ jobs:
                   fi
 
             - name: Run VirtualBox Installer - back to default repository
-              run: sudo -u user -- usr/share/usability-misc/dist-installer-cli-standalone --non-interactive --log-level=debug --no-boot --dev --ci --virtualbox-only
+              run: |
+                  sudo -u user -- usr/share/usability-misc/dist-installer-cli-standalone --non-interactive --log-level=debug --no-boot --dev --ci --virtualbox-only || {
+                    ec="$?"
+                    if grep -iq -e "debian" -e "buntu" -e "mint" /etc/os-release && test "$ec" = "108"; then
+                      printf '%s\n' "Expected error as --oracle-repo is not specified"
+                      apt-get remove -y 'virtualbox*'
+                      sudo -u user -- usr/share/usability-misc/dist-installer-cli-standalone --non-interactive --log-level=debug --no-boot --dev --ci --virtualbox-only
+                    else
+                      exit $?
+                    fi
+                  }
             - name: Run VirtualBox Installer - back to default repository - Clearnet
               run: sudo -u user -- usr/share/usability-misc/dist-installer-cli-standalone --non-interactive --log-level=debug --no-boot --dev --ci --virtualbox-only --onion
             - name: Run with non-English locale - Clearnet
               run: sudo -u user -- env LC_ALL=ru_RU.UTF-8 LANG=ru_RU.UTF-8 LANGUAGE=ru_RU usr/share/usability-misc/dist-installer-cli-standalone --non-interactive --log-level=debug --no-boot --dev --ci --import-only=both --destroy-existing-guest
-
             ## When `source`d the script should exit in less than a second because it should not perform actual work.
             ## If it was running longer that would mean that it can no longer be `source`d without actually running.
             - name: Run Bash to test 'source'ing the script

--- a/man/dist-installer-cli.1.ronn
+++ b/man/dist-installer-cli.1.ronn
@@ -191,6 +191,10 @@ Exit codes for <curl> and <rsync> are reserved to avoid conflicts and simplify d
 
     107     Failed to start virtual machines due to unforeseen issues.
 
+    108     Oracle VirtualBox package found but option `--oracle-repo` was not provided.
+
+    109     Oracle VirtualBox installed from tarball/source, but messing with packages installed from source can have unexpected results.
+
 ## AUTHOR
 
 This man page was authored by grass (grass@danwin1210.de).

--- a/usr/bin/dist-installer-cli
+++ b/usr/bin/dist-installer-cli
@@ -366,7 +366,6 @@ get_independent_host_pkgs() {
   has curl || install_pkg curl
   has rsync || install_pkg rsync
   has mokutil || install_pkg mokutil
-  has pgrep || install_pkg procps
 
   ## Install openssl and ca-certificates.
   ## openssl is required:
@@ -620,6 +619,10 @@ update_sources() {
     true "INFO: Exit code is zero but that does not guarantee in case of dnf that there is no error."
     if printf '%s' "$update_output" | grep --quiet --ignore-case "Error:" ; then
       log error "${underline}Package List Update:${nounderline} Exit code was 0 but 'Error:' found in output."
+      if printf '%s' "$update_output" | grep --quiet --ignore-case "GPG signature verification error: Signing key not"; then
+        log warn "${underline}Package List Update:${nounderline} Signing key not found. Skipping due to 'rpm --import' failing to import keys but '--assumeyes' being used will import keys"
+        return 0
+      fi
       update_sources_error
     else
       true "INFO: No error found in update output, ok."
@@ -1377,7 +1380,7 @@ get_pattern_sources_debian() {
 
   file="${1}"
   pattern="${2}"
-  grep -v "#" -- "${file}" | grep -q -E "${pattern}" || return 1
+  grep -v "^\s*#" -- "${file}" | grep -q -E "${pattern}" || return 1
 }
 
 write_sources_debian() {
@@ -1409,7 +1412,7 @@ install_package_fedora_common() {
   ## --assumeyes good or bad idea? For now not needed. So not using.
   #pkg_mngr_update( "${pkg_mngr}" 'makecache' )
   pkg_mngr_update=( "${pkg_mngr}" '--assumeyes' 'update' )
-  pkg_mngr_check_installed=( "${pkg_mngr}" 'list' 'installed' )
+  pkg_mngr_check_installed=( "${pkg_mngr}" 'list' '--installed' )
   pkg_mngr_upgrade_check=( '/bin/true' 'dnf does not seem to support an alternative to apt-get full-upgrade --simulate, skipping.' )
   pkg_mngr_upgrade_install=( "${pkg_mngr}" 'upgrade' )
 
@@ -1426,7 +1429,7 @@ install_package_fedora_common() {
   fi
 
   ## TODO: remove dnf-utils when removing Fedora 38 support from CI.
-  install_pkg torsocks redhat-lsb-core dnf-plugins-core dnf-utils
+  install_pkg torsocks redhat-lsb-core dnf-plugins-core dnf-utils procps-ng
   install_signify signify
 }
 
@@ -1499,7 +1502,7 @@ If that doesn't resolve the issue, consider reaching out to your operating syste
   update_sources
   check_upgrades_simulation
 
-  install_pkg lsb-release
+  install_pkg lsb-release procps
 
   if [ "${virtualbox_only}" = "1" ]; then
     return 0
@@ -1600,33 +1603,42 @@ kernel_modules_check() {
 
 
 install_repositories_for_virtualbox_on_debian() {
-  local distro_codename_real distro_codename_debian \
-    distro_codename_kicksecure_use oracle_clearnet oracle_prefix_debsource \
-    oracle_suffix_debsource unstable_clearnet unstable_onion \
-    unstable_prefix_debsource unstable_suffix_debsource backports_clearnet \
-    backports_onion backports_prefix_debsource backports_suffix_debsource \
-    fasttrack_clearnet fasttrack_onion fasttrack_prefix_debsource \
-    fasttrack_suffix_debsource kicksecure_clearnet kicksecure_onion \
-    kicksecure_prefix_debsource kicksecure_suffix_debsource kali_clearnet \
-    kali_prefix_debsource kali_suffix_debsource apt_torified apt_onion \
-    protocol_prefix_debsource kali_domain_debsource oracle_domain_debsource \
-    kicksecure_domain_debsource unstable_domain_debsource \
-    fasttrack_domain_debsource backports_domain_debsource
+  local distro_codename_real distro_codename_debian distro_codename_ubuntu \
+    distro_codename_kicksecure_use \
+    oracle_clearnet oracle_prefix_debsource oracle_suffix_debsource \
+    oracle_domain_debsource \
+    unstable_clearnet unstable_onion unstable_prefix_debsource \
+    unstable_suffix_debsource unstable_domain_debsource \
+    backports_clearnet backports_onion backports_prefix_debsource \
+    backports_suffix_debsource backports_domain_debsource \
+    fasttrack_clearnet fasttrack_onion fasttrack_dir_regex \
+    fasttrack_prefix_debsource fasttrack_suffix_components \
+    fasttrack_suffix_components_regex fasttrack_suffix_debsource \
+    fasttrack_suffix_debsource_regex \
+    fasttrack_backports_staging_suffix_debsource \
+    fasttrack_backports_staging_suffix_debsource_regex \
+    fasttrack_domain_debsource \
+    kicksecure_clearnet kicksecure_onion kicksecure_prefix_debsource \
+    kicksecure_suffix_debsource kicksecure_domain_debsource  \
+    kali_clearnet kali_prefix_debsource kali_suffix_debsource \
+    kali_domain_debsource  \
+    apt_torified apt_onion protocol_prefix_debsource
 
   distro_codename_real=$(lsb_release --short --codename)
   distro_codename_common_use="${distro_codename_real}"
-  ## Oracle does not have a Kali dist section, use Debian stable.
-  if [ "${kali_derivative_detected}" = "1" ]; then
-    distro_codename_debian="bookworm"
+  if [ "${ubuntu_derivative_detected}" = "1" ]; then
+    if grep -q "^UBUNTU_CODENAME=\S\+=" -- /etc/os-release; then
+      distro_codename_ubuntu="$(awk -F'=' '/^UBUNTU_CODENAME=/{print $2}' /etc/os-release)"
+    else
+      distro_codename_ubuntu="noble"
+    fi
+  elif [ "${debian_derivative_detected}" = "1" ]; then
+    if [ "${kali_derivative_detected}" = "1" ]; then
+      distro_codename_debian="bookworm"
+    else
+      distro_codename_debian="${distro_codename_common_use}"
+    fi
   fi
-
-#   log info "VirtualBox Package Availability Test: Checking if package 'virtualbox-qt' is already installable from an already enabled repository..."
-#   if "${pkg_mngr_install[@]}" --simulate install virtualbox-qt 1>/dev/null 2>/dev/null ; then
-#     ## Package 'virtualbox' is installable on Debian unstable ("sid").
-#     log notice "VirtualBox Package Availability Test Result: 'success' - Package 'virtualbox-qt' is already installable from an already enabled repository. No need to add any extra repositories."
-#     return 0
-#   fi
-#   log info "VirtualBox Package Availability Test Result: Not yet Available. Enabling additional repository..."
 
   if [ "${dev}" = "1" ]; then
     distro_codename_kicksecure_use="${distro_codename_common_use}-developers"
@@ -1640,7 +1652,9 @@ install_repositories_for_virtualbox_on_debian() {
   oracle_file_debsource="/etc/apt/sources.list.d/oracle.list"
   oracle_prefix_debsource="deb [signed-by=/usr/share/keyrings/oracle-virtualbox-2016.asc] "
   ## Oracle does not have a Kali dist section, use Debian stable.
-  if [ "${kali_derivative_detected}" = "1" ]; then
+  if [ "${ubuntu_derivative_detected}" = "1" ]; then
+    oracle_suffix_debsource="/virtualbox/debian ${distro_codename_ubuntu} contrib"
+  elif [ "${debian_derivative_detected}" = "1" ]; then
     oracle_suffix_debsource="/virtualbox/debian ${distro_codename_debian} contrib"
   else
     oracle_suffix_debsource="/virtualbox/debian ${distro_codename_common_use} contrib"
@@ -1665,11 +1679,21 @@ install_repositories_for_virtualbox_on_debian() {
   backports_suffix_debsource="/debian/ ${distro_codename_common_use}-backports main contrib non-free"
 
   fasttrack_found=""
+  fasttrack_backports_staging_found=""
   fasttrack_clearnet="fasttrack.debian.net"
   fasttrack_onion="5phjdr2nmprmhdhw4fdqfxvpvt363jyoeppewju2oqllec7ymnolieyd.onion"
   fasttrack_file_debsource="/etc/apt/sources.list.d/fasttrack.list"
+  fasttrack_backports_staging_file_debsource="/etc/apt/sources.list.d/fasttrack-backports-staging.list"
   fasttrack_prefix_debsource="deb "
-  fasttrack_suffix_debsource="/debian/ ${distro_codename_common_use}-fasttrack main contrib non-free"
+  fasttrack_dir_regex="/debian(-fasttrack)?/?\s"
+  fasttrack_suffix_components="main contrib non-free"
+  fasttrack_suffix_components_regex="main\s+contrib\s+non-free"
+  fasttrack_suite="${distro_codename_common_use}-fasttrack"
+  fasttrack_suffix_debsource="/debian-fasttrack/ ${fasttrack_suite} ${fasttrack_suffix_components}"
+  fasttrack_suffix_debsource_regex="${fasttrack_dir_regex}\s*${fasttrack_suite}\s+${fasttrack_suffix_components_regex}"
+  fasttrack_backports_staging_suite="${distro_codename_common_use}-backports-staging"
+  fasttrack_backports_staging_suffix_debsource="/debian-fasttrack/ ${fasttrack_backports_staging_suite} ${fasttrack_suffix_components}"
+  fasttrack_backports_staging_suffix_debsource_regex="${fasttrack_dir_regex}\s*${fasttrack_backports_staging_suite}\s+${fasttrack_suffix_components_regex}"
 
   kicksecure_found=""
   kicksecure_clearnet="deb.kicksecure.com"
@@ -1726,9 +1750,14 @@ install_repositories_for_virtualbox_on_debian() {
       backports_found=1
     fi
 
-    if get_pattern_sources_debian "${file}" "${fasttrack_clearnet}|${fasttrack_onion}"
+    if get_pattern_sources_debian "${file}" "(${fasttrack_clearnet}|${fasttrack_onion})${fasttrack_suffix_debsource_regex}"
     then
       fasttrack_found=1
+    fi
+
+    if get_pattern_sources_debian "${file}" "(${fasttrack_clearnet}|${fasttrack_onion})${fasttrack_backports_staging_suffix_debsource_regex}"
+    then
+      fasttrack_backports_staging_found=1
     fi
 
     if get_pattern_sources_debian "${file}" "${kali_clearnet}"
@@ -1795,10 +1824,11 @@ install_repositories_for_virtualbox_on_debian() {
     else
       kali_domain_debsource="${kali_clearnet}"
       oracle_domain_debsource="${oracle_clearnet}"
+      log warn "Fallback Fasttrack repository to clearnet"
+      fasttrack_domain_debsource="${fasttrack_clearnet}"
     fi
     kicksecure_domain_debsource="${kicksecure_onion}"
     unstable_domain_debsource="${unstable_onion}"
-    fasttrack_domain_debsource="${fasttrack_onion}"
     backports_domain_debsource="${backports_onion}"
   ## If user has torified repositories configured, prefer it.
   elif [ "${apt_torified}" = '1' ]; then
@@ -1822,11 +1852,12 @@ install_repositories_for_virtualbox_on_debian() {
     kali_domain_debsource="${kali_clearnet}"
   fi
 
-  kicksecure_url="${kicksecure_prefix_debsource} ${protocol_prefix_debsource}${kicksecure_domain_debsource}${kicksecure_suffix_debsource}"
-  unstable_url="${unstable_prefix_debsource} ${protocol_prefix_debsource}${unstable_domain_debsource}${unstable_suffix_debsource}"
-  fasttrack_url="${fasttrack_prefix_debsource} ${protocol_prefix_debsource}${fasttrack_domain_debsource}${fasttrack_suffix_debsource}"
-  backports_url="${backports_prefix_debsource} ${protocol_prefix_debsource}${backports_domain_debsource}${backports_suffix_debsource}"
-  kali_url="${kali_prefix_debsource} ${protocol_prefix_debsource}${kali_domain_debsource}${kali_suffix_debsource}"
+  kicksecure_url="${kicksecure_prefix_debsource}${protocol_prefix_debsource}${kicksecure_domain_debsource}${kicksecure_suffix_debsource}"
+  unstable_url="${unstable_prefix_debsource}${protocol_prefix_debsource}${unstable_domain_debsource}${unstable_suffix_debsource}"
+  fasttrack_url="${fasttrack_prefix_debsource}${protocol_prefix_debsource}${fasttrack_domain_debsource}${fasttrack_suffix_debsource}"
+  fasttrack_backports_staging_url="${fasttrack_prefix_debsource}${protocol_prefix_debsource}${fasttrack_domain_debsource}${fasttrack_backports_staging_suffix_debsource}"
+  backports_url="${backports_prefix_debsource}${protocol_prefix_debsource}${backports_domain_debsource}${backports_suffix_debsource}"
+  kali_url="${kali_prefix_debsource}${protocol_prefix_debsource}${kali_domain_debsource}${kali_suffix_debsource}"
 
   if [ "${oracle_repo}" = "1" ]; then
     oracle_url="${oracle_prefix_debsource} ${protocol_prefix_debsource}${oracle_domain_debsource}${oracle_suffix_debsource}"
@@ -1835,11 +1866,7 @@ install_repositories_for_virtualbox_on_debian() {
   fi
 
   case "${distro_codename_real}" in
-    bullseye)
-      install_backports_and_fasttrack_repository_debian
-      return 0
-      ;;
-    bookworm)
+    bullseye|bookworm)
       install_backports_and_fasttrack_repository_debian
       return 0
       ;;
@@ -1852,6 +1879,11 @@ install_repositories_for_virtualbox_on_debian() {
       return 0
       ;;
   esac
+  if test "${ubuntu_derivative_detected}" = "1"; then
+    ## Doesn't require extra repository, but this function is used to get
+    ## Oracle repository information and protocol (onion, https, tor+http etc)
+    return 0
+  fi
 
   die 1 "${underline}Repository Add:${nounderline} Unsupported distribution codename: '${distro_codename_real}'!"
 }
@@ -1876,7 +1908,6 @@ install_oracle_repository_fedora() {
         run_as_target_user tee -- "${log_dir_cur}/oracle-virtualbox-2016.asc" >/dev/null
       printf '%s\n' "${oracle_pgp}" | \
         root_cmd tee -- /etc/pki/rpm-gpg/RPM-GPG-KEY-oracle >/dev/null
-      ## Optional: the key will be imported when trying to use the repository
       root_cmd rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
     fi
 
@@ -2001,6 +2032,14 @@ install_backports_and_fasttrack_repository_debian() {
     write_sources_debian "${fasttrack_url}" "${fasttrack_file_debsource}"
   fi
 
+  if [ "${fasttrack_backports_staging_found}" = "1" ]; then
+    log info "APT Repository Configuration: Skipped adding 'fasttrack' with suite '${fasttrack_backports_staging_suite}' repository because it was already found."
+  else
+    log notice "APT Repository Configuration: Adding 'fasttrack' ${connection_type_debsource} repository with suite '${fasttrack_backports_staging_suite}' to ${fasttrack_file_debsource}"
+    write_sources_debian "${fasttrack_backports_staging_url}" "${fasttrack_backports_staging_file_debsource}"
+  fi
+
+
   ## virtualbox-guest-additions-iso is available from Debian stable and fasttrack.
   ## Debian stable version however is outdated.
   ## If not using APT with option '--target-release=bookworm-fasttrack' then
@@ -2068,7 +2107,7 @@ install_virtualbox_fedora() {
 
   get_virtualbox_version_fedora() {
     ## Too many issues with auto detection. Therefore hardcoded.
-    virtualbox_qt_package_name="VirtualBox-7.0"
+    virtualbox_qt_package_name="VirtualBox-7.1"
     return 0
 
 #     log info "VirtualBox Version Detection: Running 'dnf search VirtualBox-*'. This can take a while..."
@@ -2119,10 +2158,9 @@ get_virtualbox_version_debian() {
   local virtualbox_version
 
   if [ "${oracle_repo}" = "1" ]; then
-    virtualbox_version=$(apt-cache search --names-only --quiet "^virtualbox-[[:digit:]]{1,2}\.[[:digit:]]{1,2}$")
-    virtualbox_version=$(printf '%s' "$virtualbox_version" | tail -1)
-    virtualbox_version=$(printf '%s' "$virtualbox_version" | cut -d " " -f1)
-    virtualbox_version=$(printf '%s' "$virtualbox_version" | cut -d "-" -f2-)
+    virtualbox_version=$("${virtualbox_cache_version_cmd[@]}" | tail -1)
+    virtualbox_version=${virtualbox_version#virtualbox-}
+    virtualbox_version=${virtualbox_version%% *}
     virtualbox_qt_package_name=virtualbox-"${virtualbox_version}"
     ## Package virtualbox-guest-additions-iso is unavailable from Oracle repository.
     virtualbox_guest_additions_iso_package_name=""
@@ -2141,12 +2179,9 @@ get_virtualbox_version_debian() {
 }
 
 
-
-## Install VirtualBox on Debian
-## See also comments for install_virtualbox_fedora.
-install_virtualbox_debian() {
-  local linux_image linux_headers install_virtualbox_args
-
+## Begin installation of VirtualBox on Debian and derived systems.
+install_virtualbox_debian_common_begin() {
+  log notice "VirtualBox Installation: Preparing to install VirtualBox..."
   if [ "${oracle_repo}" = "1" ]; then
     ## Workaround for undeclared dependencies bug by virtualbox.org (Oracle) repository.
     ##
@@ -2159,16 +2194,41 @@ install_virtualbox_debian() {
     install_pkg gcc udev
   fi
 
+  virtualbox_cache_version_cmd=('apt-cache' 'search' '--names-only' '--quiet' '^virtualbox-[[:digit:]]{1,2}\.[[:digit:]]{1,2}$')
+  ## Dealing with installation from tarball is not possible, we can identify
+  ## if 'vboxmanage' is in the PATH while no related package was found, but
+  ## then there is not a way to clearly explain to the user that they should
+  ## remove TODO
+  if [ "${oracle_repo}" != '1' ]; then
+    for pkg in $("${virtualbox_cache_version_cmd[@]}" | cut -d " " -f1); do
+      if "${pkg_mngr_check_installed[@]}" "${pkg}" >/dev/null 2>&1; then
+        die 108 "Found Oracle VirtualBox package but option '--oracle-repo' was not set! Run with the option '--oracle-repo' or uninstall the package '$pkg' and then rerun this script."
+      fi
+    done
+  fi
+  if has vboxmanage && ! dpkg --search "$(command -v vboxmanage)"; then
+    die 109 "Found Oracle VirtualBox installed from tarball/source, using a package manager can conflict with yourinstalled program. Uninstall VirtualBox first and then rerun this script. Use the option '--oracle-repo' if you want to keep close to upstream releases."
+  fi
+
+  install_repositories_for_virtualbox_on_debian
+  update_sources
+  check_upgrades_simulation
+  get_virtualbox_version_debian || die 2 "${underline}VirtualBox Package Version Detection:${nounderline} 'FAIL'"
+
+}
+
+
+## Install VirtualBox on Debian
+## See also comments for install_virtualbox_fedora.
+install_virtualbox_debian() {
+  local linux_image linux_headers install_virtualbox_args
+
   linux_image="linux-image-$(dpkg --print-architecture)"
   linux_headers="linux-headers-$(dpkg --print-architecture)"
   ## Doing here and now below because we $install_pkg_fasttrack_extra_args_maybe should not be used here.
   install_pkg "${linux_image}" "${linux_headers}"
 
-  log notice "VirtualBox Installation: Preparing to install VirtualBox..."
-  install_repositories_for_virtualbox_on_debian
-  update_sources
-  check_upgrades_simulation
-  get_virtualbox_version_debian || die 2 "${underline}VirtualBox Package Version Detection:${nounderline} 'FAIL'"
+  install_virtualbox_debian_common_begin
 
   install_virtualbox_args=()
   [ "${#install_pkg_fasttrack_extra_args_maybe[@]}" != '0' ] \
@@ -2184,7 +2244,14 @@ install_virtualbox_debian() {
 
 ## Install VirtualBox on Ubuntu
 install_virtualbox_ubuntu() {
-  install_pkg virtualbox-qt virtualbox-guest-additions-iso linux-image-generic linux-headers-generic
+  install_virtualbox_debian_common_begin
+  install_virtualbox_args=()
+  [ "${#install_pkg_fasttrack_extra_args_maybe[@]}" != '0' ] \
+    && install_virtualbox_args+=( "${install_pkg_fasttrack_extra_args_maybe[@]}" )
+  install_virtualbox_args+=( "${virtualbox_qt_package_name}" )
+  [ -n "${virtualbox_guest_additions_iso_package_name}" ] \
+    && install_virtualbox_args+=( "${virtualbox_guest_additions_iso_package_name}" )
+  install_pkg "${install_virtualbox_args[@]}" linux-image-generic linux-headers-generic
   install_virtualbox_debian_common_end
 }
 

--- a/usr/bin/dist-installer-cli
+++ b/usr/bin/dist-installer-cli
@@ -1428,8 +1428,17 @@ install_package_fedora_common() {
     return 0
   fi
 
-  ## TODO: remove dnf-utils when removing Fedora 38 support from CI.
-  install_pkg torsocks redhat-lsb-core dnf-plugins-core dnf-utils procps-ng
+  install_pkg torsocks dnf-plugins-core procps-ng
+
+  ## Conflicting packages requires '--allowerasing'.
+  if "${pkg_mngr_check_installed[@]}" lsb_release >/dev/null 2>&1 ||
+    "${pkg_mngr_check_installed[@]}" redhat-lsb-core >/dev/null 2>&1
+  then
+    true
+  else
+    install_pkg lsb_release >/dev/null 2>&1
+  fi
+
   install_signify signify
 }
 

--- a/usr/share/usability-misc/dist-installer-cli-standalone
+++ b/usr/share/usability-misc/dist-installer-cli-standalone
@@ -2107,8 +2107,17 @@ install_package_fedora_common() {
     return 0
   fi
 
-  ## TODO: remove dnf-utils when removing Fedora 38 support from CI.
-  install_pkg torsocks redhat-lsb-core dnf-plugins-core dnf-utils procps-ng
+  install_pkg torsocks dnf-plugins-core procps-ng
+
+  ## Conflicting packages requires '--allowerasing'.
+  if "${pkg_mngr_check_installed[@]}" lsb_release >/dev/null 2>&1 ||
+    "${pkg_mngr_check_installed[@]}" redhat-lsb-core >/dev/null 2>&1
+  then
+    true
+  else
+    install_pkg lsb_release >/dev/null 2>&1
+  fi
+
   install_signify signify
 }
 

--- a/usr/share/usability-misc/dist-installer-cli-standalone
+++ b/usr/share/usability-misc/dist-installer-cli-standalone
@@ -1045,7 +1045,6 @@ get_independent_host_pkgs() {
   has curl || install_pkg curl
   has rsync || install_pkg rsync
   has mokutil || install_pkg mokutil
-  has pgrep || install_pkg procps
 
   ## Install openssl and ca-certificates.
   ## openssl is required:
@@ -1299,6 +1298,10 @@ update_sources() {
     true "INFO: Exit code is zero but that does not guarantee in case of dnf that there is no error."
     if printf '%s' "$update_output" | grep --quiet --ignore-case "Error:" ; then
       log error "${underline}Package List Update:${nounderline} Exit code was 0 but 'Error:' found in output."
+      if printf '%s' "$update_output" | grep --quiet --ignore-case "GPG signature verification error: Signing key not"; then
+        log warn "${underline}Package List Update:${nounderline} Signing key not found. Skipping due to 'rpm --import' failing to import keys but '--assumeyes' being used will import keys"
+        return 0
+      fi
       update_sources_error
     else
       true "INFO: No error found in update output, ok."
@@ -2056,7 +2059,7 @@ get_pattern_sources_debian() {
 
   file="${1}"
   pattern="${2}"
-  grep -v "#" -- "${file}" | grep -q -E "${pattern}" || return 1
+  grep -v "^\s*#" -- "${file}" | grep -q -E "${pattern}" || return 1
 }
 
 write_sources_debian() {
@@ -2088,7 +2091,7 @@ install_package_fedora_common() {
   ## --assumeyes good or bad idea? For now not needed. So not using.
   #pkg_mngr_update( "${pkg_mngr}" 'makecache' )
   pkg_mngr_update=( "${pkg_mngr}" '--assumeyes' 'update' )
-  pkg_mngr_check_installed=( "${pkg_mngr}" 'list' 'installed' )
+  pkg_mngr_check_installed=( "${pkg_mngr}" 'list' '--installed' )
   pkg_mngr_upgrade_check=( '/bin/true' 'dnf does not seem to support an alternative to apt-get full-upgrade --simulate, skipping.' )
   pkg_mngr_upgrade_install=( "${pkg_mngr}" 'upgrade' )
 
@@ -2105,7 +2108,7 @@ install_package_fedora_common() {
   fi
 
   ## TODO: remove dnf-utils when removing Fedora 38 support from CI.
-  install_pkg torsocks redhat-lsb-core dnf-plugins-core dnf-utils
+  install_pkg torsocks redhat-lsb-core dnf-plugins-core dnf-utils procps-ng
   install_signify signify
 }
 
@@ -2178,7 +2181,7 @@ If that doesn't resolve the issue, consider reaching out to your operating syste
   update_sources
   check_upgrades_simulation
 
-  install_pkg lsb-release
+  install_pkg lsb-release procps
 
   if [ "${virtualbox_only}" = "1" ]; then
     return 0
@@ -2279,33 +2282,42 @@ kernel_modules_check() {
 
 
 install_repositories_for_virtualbox_on_debian() {
-  local distro_codename_real distro_codename_debian \
-    distro_codename_kicksecure_use oracle_clearnet oracle_prefix_debsource \
-    oracle_suffix_debsource unstable_clearnet unstable_onion \
-    unstable_prefix_debsource unstable_suffix_debsource backports_clearnet \
-    backports_onion backports_prefix_debsource backports_suffix_debsource \
-    fasttrack_clearnet fasttrack_onion fasttrack_prefix_debsource \
-    fasttrack_suffix_debsource kicksecure_clearnet kicksecure_onion \
-    kicksecure_prefix_debsource kicksecure_suffix_debsource kali_clearnet \
-    kali_prefix_debsource kali_suffix_debsource apt_torified apt_onion \
-    protocol_prefix_debsource kali_domain_debsource oracle_domain_debsource \
-    kicksecure_domain_debsource unstable_domain_debsource \
-    fasttrack_domain_debsource backports_domain_debsource
+  local distro_codename_real distro_codename_debian distro_codename_ubuntu \
+    distro_codename_kicksecure_use \
+    oracle_clearnet oracle_prefix_debsource oracle_suffix_debsource \
+    oracle_domain_debsource \
+    unstable_clearnet unstable_onion unstable_prefix_debsource \
+    unstable_suffix_debsource unstable_domain_debsource \
+    backports_clearnet backports_onion backports_prefix_debsource \
+    backports_suffix_debsource backports_domain_debsource \
+    fasttrack_clearnet fasttrack_onion fasttrack_dir_regex \
+    fasttrack_prefix_debsource fasttrack_suffix_components \
+    fasttrack_suffix_components_regex fasttrack_suffix_debsource \
+    fasttrack_suffix_debsource_regex \
+    fasttrack_backports_staging_suffix_debsource \
+    fasttrack_backports_staging_suffix_debsource_regex \
+    fasttrack_domain_debsource \
+    kicksecure_clearnet kicksecure_onion kicksecure_prefix_debsource \
+    kicksecure_suffix_debsource kicksecure_domain_debsource  \
+    kali_clearnet kali_prefix_debsource kali_suffix_debsource \
+    kali_domain_debsource  \
+    apt_torified apt_onion protocol_prefix_debsource
 
   distro_codename_real=$(lsb_release --short --codename)
   distro_codename_common_use="${distro_codename_real}"
-  ## Oracle does not have a Kali dist section, use Debian stable.
-  if [ "${kali_derivative_detected}" = "1" ]; then
-    distro_codename_debian="bookworm"
+  if [ "${ubuntu_derivative_detected}" = "1" ]; then
+    if grep -q "^UBUNTU_CODENAME=\S\+=" -- /etc/os-release; then
+      distro_codename_ubuntu="$(awk -F'=' '/^UBUNTU_CODENAME=/{print $2}' /etc/os-release)"
+    else
+      distro_codename_ubuntu="noble"
+    fi
+  elif [ "${debian_derivative_detected}" = "1" ]; then
+    if [ "${kali_derivative_detected}" = "1" ]; then
+      distro_codename_debian="bookworm"
+    else
+      distro_codename_debian="${distro_codename_common_use}"
+    fi
   fi
-
-#   log info "VirtualBox Package Availability Test: Checking if package 'virtualbox-qt' is already installable from an already enabled repository..."
-#   if "${pkg_mngr_install[@]}" --simulate install virtualbox-qt 1>/dev/null 2>/dev/null ; then
-#     ## Package 'virtualbox' is installable on Debian unstable ("sid").
-#     log notice "VirtualBox Package Availability Test Result: 'success' - Package 'virtualbox-qt' is already installable from an already enabled repository. No need to add any extra repositories."
-#     return 0
-#   fi
-#   log info "VirtualBox Package Availability Test Result: Not yet Available. Enabling additional repository..."
 
   if [ "${dev}" = "1" ]; then
     distro_codename_kicksecure_use="${distro_codename_common_use}-developers"
@@ -2319,7 +2331,9 @@ install_repositories_for_virtualbox_on_debian() {
   oracle_file_debsource="/etc/apt/sources.list.d/oracle.list"
   oracle_prefix_debsource="deb [signed-by=/usr/share/keyrings/oracle-virtualbox-2016.asc] "
   ## Oracle does not have a Kali dist section, use Debian stable.
-  if [ "${kali_derivative_detected}" = "1" ]; then
+  if [ "${ubuntu_derivative_detected}" = "1" ]; then
+    oracle_suffix_debsource="/virtualbox/debian ${distro_codename_ubuntu} contrib"
+  elif [ "${debian_derivative_detected}" = "1" ]; then
     oracle_suffix_debsource="/virtualbox/debian ${distro_codename_debian} contrib"
   else
     oracle_suffix_debsource="/virtualbox/debian ${distro_codename_common_use} contrib"
@@ -2344,11 +2358,21 @@ install_repositories_for_virtualbox_on_debian() {
   backports_suffix_debsource="/debian/ ${distro_codename_common_use}-backports main contrib non-free"
 
   fasttrack_found=""
+  fasttrack_backports_staging_found=""
   fasttrack_clearnet="fasttrack.debian.net"
   fasttrack_onion="5phjdr2nmprmhdhw4fdqfxvpvt363jyoeppewju2oqllec7ymnolieyd.onion"
   fasttrack_file_debsource="/etc/apt/sources.list.d/fasttrack.list"
+  fasttrack_backports_staging_file_debsource="/etc/apt/sources.list.d/fasttrack-backports-staging.list"
   fasttrack_prefix_debsource="deb "
-  fasttrack_suffix_debsource="/debian/ ${distro_codename_common_use}-fasttrack main contrib non-free"
+  fasttrack_dir_regex="/debian(-fasttrack)?/?\s"
+  fasttrack_suffix_components="main contrib non-free"
+  fasttrack_suffix_components_regex="main\s+contrib\s+non-free"
+  fasttrack_suite="${distro_codename_common_use}-fasttrack"
+  fasttrack_suffix_debsource="/debian-fasttrack/ ${fasttrack_suite} ${fasttrack_suffix_components}"
+  fasttrack_suffix_debsource_regex="${fasttrack_dir_regex}\s*${fasttrack_suite}\s+${fasttrack_suffix_components_regex}"
+  fasttrack_backports_staging_suite="${distro_codename_common_use}-backports-staging"
+  fasttrack_backports_staging_suffix_debsource="/debian-fasttrack/ ${fasttrack_backports_staging_suite} ${fasttrack_suffix_components}"
+  fasttrack_backports_staging_suffix_debsource_regex="${fasttrack_dir_regex}\s*${fasttrack_backports_staging_suite}\s+${fasttrack_suffix_components_regex}"
 
   kicksecure_found=""
   kicksecure_clearnet="deb.kicksecure.com"
@@ -2405,9 +2429,14 @@ install_repositories_for_virtualbox_on_debian() {
       backports_found=1
     fi
 
-    if get_pattern_sources_debian "${file}" "${fasttrack_clearnet}|${fasttrack_onion}"
+    if get_pattern_sources_debian "${file}" "(${fasttrack_clearnet}|${fasttrack_onion})${fasttrack_suffix_debsource_regex}"
     then
       fasttrack_found=1
+    fi
+
+    if get_pattern_sources_debian "${file}" "(${fasttrack_clearnet}|${fasttrack_onion})${fasttrack_backports_staging_suffix_debsource_regex}"
+    then
+      fasttrack_backports_staging_found=1
     fi
 
     if get_pattern_sources_debian "${file}" "${kali_clearnet}"
@@ -2474,10 +2503,11 @@ install_repositories_for_virtualbox_on_debian() {
     else
       kali_domain_debsource="${kali_clearnet}"
       oracle_domain_debsource="${oracle_clearnet}"
+      log warn "Fallback Fasttrack repository to clearnet"
+      fasttrack_domain_debsource="${fasttrack_clearnet}"
     fi
     kicksecure_domain_debsource="${kicksecure_onion}"
     unstable_domain_debsource="${unstable_onion}"
-    fasttrack_domain_debsource="${fasttrack_onion}"
     backports_domain_debsource="${backports_onion}"
   ## If user has torified repositories configured, prefer it.
   elif [ "${apt_torified}" = '1' ]; then
@@ -2501,11 +2531,12 @@ install_repositories_for_virtualbox_on_debian() {
     kali_domain_debsource="${kali_clearnet}"
   fi
 
-  kicksecure_url="${kicksecure_prefix_debsource} ${protocol_prefix_debsource}${kicksecure_domain_debsource}${kicksecure_suffix_debsource}"
-  unstable_url="${unstable_prefix_debsource} ${protocol_prefix_debsource}${unstable_domain_debsource}${unstable_suffix_debsource}"
-  fasttrack_url="${fasttrack_prefix_debsource} ${protocol_prefix_debsource}${fasttrack_domain_debsource}${fasttrack_suffix_debsource}"
-  backports_url="${backports_prefix_debsource} ${protocol_prefix_debsource}${backports_domain_debsource}${backports_suffix_debsource}"
-  kali_url="${kali_prefix_debsource} ${protocol_prefix_debsource}${kali_domain_debsource}${kali_suffix_debsource}"
+  kicksecure_url="${kicksecure_prefix_debsource}${protocol_prefix_debsource}${kicksecure_domain_debsource}${kicksecure_suffix_debsource}"
+  unstable_url="${unstable_prefix_debsource}${protocol_prefix_debsource}${unstable_domain_debsource}${unstable_suffix_debsource}"
+  fasttrack_url="${fasttrack_prefix_debsource}${protocol_prefix_debsource}${fasttrack_domain_debsource}${fasttrack_suffix_debsource}"
+  fasttrack_backports_staging_url="${fasttrack_prefix_debsource}${protocol_prefix_debsource}${fasttrack_domain_debsource}${fasttrack_backports_staging_suffix_debsource}"
+  backports_url="${backports_prefix_debsource}${protocol_prefix_debsource}${backports_domain_debsource}${backports_suffix_debsource}"
+  kali_url="${kali_prefix_debsource}${protocol_prefix_debsource}${kali_domain_debsource}${kali_suffix_debsource}"
 
   if [ "${oracle_repo}" = "1" ]; then
     oracle_url="${oracle_prefix_debsource} ${protocol_prefix_debsource}${oracle_domain_debsource}${oracle_suffix_debsource}"
@@ -2514,11 +2545,7 @@ install_repositories_for_virtualbox_on_debian() {
   fi
 
   case "${distro_codename_real}" in
-    bullseye)
-      install_backports_and_fasttrack_repository_debian
-      return 0
-      ;;
-    bookworm)
+    bullseye|bookworm)
       install_backports_and_fasttrack_repository_debian
       return 0
       ;;
@@ -2531,6 +2558,11 @@ install_repositories_for_virtualbox_on_debian() {
       return 0
       ;;
   esac
+  if test "${ubuntu_derivative_detected}" = "1"; then
+    ## Doesn't require extra repository, but this function is used to get
+    ## Oracle repository information and protocol (onion, https, tor+http etc)
+    return 0
+  fi
 
   die 1 "${underline}Repository Add:${nounderline} Unsupported distribution codename: '${distro_codename_real}'!"
 }
@@ -2555,7 +2587,6 @@ install_oracle_repository_fedora() {
         run_as_target_user tee -- "${log_dir_cur}/oracle-virtualbox-2016.asc" >/dev/null
       printf '%s\n' "${oracle_pgp}" | \
         root_cmd tee -- /etc/pki/rpm-gpg/RPM-GPG-KEY-oracle >/dev/null
-      ## Optional: the key will be imported when trying to use the repository
       root_cmd rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
     fi
 
@@ -2680,6 +2711,14 @@ install_backports_and_fasttrack_repository_debian() {
     write_sources_debian "${fasttrack_url}" "${fasttrack_file_debsource}"
   fi
 
+  if [ "${fasttrack_backports_staging_found}" = "1" ]; then
+    log info "APT Repository Configuration: Skipped adding 'fasttrack' with suite '${fasttrack_backports_staging_suite}' repository because it was already found."
+  else
+    log notice "APT Repository Configuration: Adding 'fasttrack' ${connection_type_debsource} repository with suite '${fasttrack_backports_staging_suite}' to ${fasttrack_file_debsource}"
+    write_sources_debian "${fasttrack_backports_staging_url}" "${fasttrack_backports_staging_file_debsource}"
+  fi
+
+
   ## virtualbox-guest-additions-iso is available from Debian stable and fasttrack.
   ## Debian stable version however is outdated.
   ## If not using APT with option '--target-release=bookworm-fasttrack' then
@@ -2747,7 +2786,7 @@ install_virtualbox_fedora() {
 
   get_virtualbox_version_fedora() {
     ## Too many issues with auto detection. Therefore hardcoded.
-    virtualbox_qt_package_name="VirtualBox-7.0"
+    virtualbox_qt_package_name="VirtualBox-7.1"
     return 0
 
 #     log info "VirtualBox Version Detection: Running 'dnf search VirtualBox-*'. This can take a while..."
@@ -2798,10 +2837,9 @@ get_virtualbox_version_debian() {
   local virtualbox_version
 
   if [ "${oracle_repo}" = "1" ]; then
-    virtualbox_version=$(apt-cache search --names-only --quiet "^virtualbox-[[:digit:]]{1,2}\.[[:digit:]]{1,2}$")
-    virtualbox_version=$(printf '%s' "$virtualbox_version" | tail -1)
-    virtualbox_version=$(printf '%s' "$virtualbox_version" | cut -d " " -f1)
-    virtualbox_version=$(printf '%s' "$virtualbox_version" | cut -d "-" -f2-)
+    virtualbox_version=$("${virtualbox_cache_version_cmd[@]}" | tail -1)
+    virtualbox_version=${virtualbox_version#virtualbox-}
+    virtualbox_version=${virtualbox_version%% *}
     virtualbox_qt_package_name=virtualbox-"${virtualbox_version}"
     ## Package virtualbox-guest-additions-iso is unavailable from Oracle repository.
     virtualbox_guest_additions_iso_package_name=""
@@ -2820,12 +2858,9 @@ get_virtualbox_version_debian() {
 }
 
 
-
-## Install VirtualBox on Debian
-## See also comments for install_virtualbox_fedora.
-install_virtualbox_debian() {
-  local linux_image linux_headers install_virtualbox_args
-
+## Begin installation of VirtualBox on Debian and derived systems.
+install_virtualbox_debian_common_begin() {
+  log notice "VirtualBox Installation: Preparing to install VirtualBox..."
   if [ "${oracle_repo}" = "1" ]; then
     ## Workaround for undeclared dependencies bug by virtualbox.org (Oracle) repository.
     ##
@@ -2838,16 +2873,41 @@ install_virtualbox_debian() {
     install_pkg gcc udev
   fi
 
+  virtualbox_cache_version_cmd=('apt-cache' 'search' '--names-only' '--quiet' '^virtualbox-[[:digit:]]{1,2}\.[[:digit:]]{1,2}$')
+  ## Dealing with installation from tarball is not possible, we can identify
+  ## if 'vboxmanage' is in the PATH while no related package was found, but
+  ## then there is not a way to clearly explain to the user that they should
+  ## remove TODO
+  if [ "${oracle_repo}" != '1' ]; then
+    for pkg in $("${virtualbox_cache_version_cmd[@]}" | cut -d " " -f1); do
+      if "${pkg_mngr_check_installed[@]}" "${pkg}" >/dev/null 2>&1; then
+        die 108 "Found Oracle VirtualBox package but option '--oracle-repo' was not set! Run with the option '--oracle-repo' or uninstall the package '$pkg' and then rerun this script."
+      fi
+    done
+  fi
+  if has vboxmanage && ! dpkg --search "$(command -v vboxmanage)"; then
+    die 109 "Found Oracle VirtualBox installed from tarball/source, using a package manager can conflict with yourinstalled program. Uninstall VirtualBox first and then rerun this script. Use the option '--oracle-repo' if you want to keep close to upstream releases."
+  fi
+
+  install_repositories_for_virtualbox_on_debian
+  update_sources
+  check_upgrades_simulation
+  get_virtualbox_version_debian || die 2 "${underline}VirtualBox Package Version Detection:${nounderline} 'FAIL'"
+
+}
+
+
+## Install VirtualBox on Debian
+## See also comments for install_virtualbox_fedora.
+install_virtualbox_debian() {
+  local linux_image linux_headers install_virtualbox_args
+
   linux_image="linux-image-$(dpkg --print-architecture)"
   linux_headers="linux-headers-$(dpkg --print-architecture)"
   ## Doing here and now below because we $install_pkg_fasttrack_extra_args_maybe should not be used here.
   install_pkg "${linux_image}" "${linux_headers}"
 
-  log notice "VirtualBox Installation: Preparing to install VirtualBox..."
-  install_repositories_for_virtualbox_on_debian
-  update_sources
-  check_upgrades_simulation
-  get_virtualbox_version_debian || die 2 "${underline}VirtualBox Package Version Detection:${nounderline} 'FAIL'"
+  install_virtualbox_debian_common_begin
 
   install_virtualbox_args=()
   [ "${#install_pkg_fasttrack_extra_args_maybe[@]}" != '0' ] \
@@ -2863,7 +2923,14 @@ install_virtualbox_debian() {
 
 ## Install VirtualBox on Ubuntu
 install_virtualbox_ubuntu() {
-  install_pkg virtualbox-qt virtualbox-guest-additions-iso linux-image-generic linux-headers-generic
+  install_virtualbox_debian_common_begin
+  install_virtualbox_args=()
+  [ "${#install_pkg_fasttrack_extra_args_maybe[@]}" != '0' ] \
+    && install_virtualbox_args+=( "${install_pkg_fasttrack_extra_args_maybe[@]}" )
+  install_virtualbox_args+=( "${virtualbox_qt_package_name}" )
+  [ -n "${virtualbox_guest_additions_iso_package_name}" ] \
+    && install_virtualbox_args+=( "${virtualbox_guest_additions_iso_package_name}" )
+  install_pkg "${install_virtualbox_args[@]}" linux-image-generic linux-headers-generic
   install_virtualbox_debian_common_end
 }
 


### PR DESCRIPTION
## Changes

- Do not downgrade VirtualBox if Oracle package is found, instead, fail informing that option `--oracle-repo` is necessary or uninstall of the package
- Add missing fasttrack suite backports-staging
- Ubuntu VirtualBox package is old, use the same method as Debian if Oracle package is found as well as share the function to add oracle repo to Ubuntu.
- Fix Fedora package names

I haven't tested this Ubuntu, will rely on CI for that.

It can still downgrade if user installed VirtualBox via tarball, I can try to test for:

- If vboxmanage command is present but not virtualbox package is, inform that `--oracle-repo` is necessary.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
