### PR TITLE
Fix bugs and improve VM import handling

### DIFF
--- a/man/dist-installer-cli.1.ronn
+++ b/man/dist-installer-cli.1.ronn
@@ -62,7 +62,7 @@ format <guest-interface-installer>.
 `-l`, `--log-level`=<level>
 
         Define the logging level. Options: debug, info, notice (default), warn, error.
-        Log messages below the specified level are displayed.
+        Log messages at or above the specified level are displayed.
 
 `-k`, `--no-boot`
 
@@ -115,10 +115,6 @@ format <guest-interface-installer>.
 `--allow-errors`
 
         Enable dirty mode, where the program continues despite errors.
-
-`--no-show-errors`
-
-        Suppress error messages.
 
 `--ci`
 

--- a/man/dist-installer-cli.1.ronn
+++ b/man/dist-installer-cli.1.ronn
@@ -132,7 +132,7 @@ format <guest-interface-installer>.
 
         Activate development mode, which sets the default download version to an empty image.
 
-`--noupgrade`
+`--noupdate`
 
         Skip package manager list update. For development only.
 

--- a/usr/bin/dist-installer-cli
+++ b/usr/bin/dist-installer-cli
@@ -1356,7 +1356,7 @@ import_guest() {
   fi
 
   if [ "${no_import}" = "1" ]; then
-    log notice "VM Import: Not importing guest via '--import-only' option."
+    log notice "VM Import: Not importing guest via '--no-import' option."
     end_installer
   fi
 
@@ -3670,8 +3670,8 @@ get_download_links() {
       ;;
     *)
       ## Variables need to be set for --virtualbox-only.
-      site_clearnet="${site_onion_kicksecure}"
-      site_onion="${site_clearnet_kicksecure}"
+      site_clearnet="${site_clearnet_kicksecure}"
+      site_onion="${site_onion_kicksecure}"
       ;;
   esac
 
@@ -4594,7 +4594,7 @@ log_term_and_file() {
       2> >(run_as_target_user tee -a -- "${log_file_debug}" >&2)
 
   temp_folder="$(mktemp --directory)"
-  xtrace_fifo="/${temp_folder}/xtrace_fifo"
+  xtrace_fifo="${temp_folder}/xtrace_fifo"
   mkfifo -m 600 -- "$xtrace_fifo"
 
   if [ "${log_level}" = "debug" ] || test -o xtrace; then

--- a/usr/bin/dist-installer-cli
+++ b/usr/bin/dist-installer-cli
@@ -984,6 +984,13 @@ test_pkg() {
 
 
 check_vm_running_general() {
+  if [ "${virtualbox_only}" = "1" ]; then
+    return 0
+  fi
+  if [ "${hypervisor}" = "kvm" ]; then
+    return 0
+  fi
+
   case "${guest}" in
     whonix)
         check_vm_running_virtualbox "${guest_full_vm_name_gateway}"
@@ -3847,7 +3854,7 @@ check_hash() {
 
   shafile="${1}"
   dir="$(dirname -- "${shafile}")"
-  log info "Checking SHA512 checksum: '${shafile}"
+  log info "Checking SHA512 checksum: '${shafile}'"
   ## $checkhash needs to be executed on the same folder as the compared file.
   log info "Changing to directory: '${dir}'"
   if [ -n "${target_user}" ]; then
@@ -4050,7 +4057,7 @@ Developer options:
                          2 [HU] quantum-mirror.hu
  --redownload        Re-download the guest image, even if previously successful.
  --import-only=<vm>  Select specific VM to import. Only if guest is Whonix.
-                       Options: workstation, gateway.
+                       Options: workstation, gateway, both.
  --no-import         Skip guest import. Default behavior is to import.
  --destroy-existing-guest Deletes any existing virtual machine(s) and re-imports them.
                        Warning: This action poses a risk of data loss as it involves

--- a/usr/bin/dist-installer-cli
+++ b/usr/bin/dist-installer-cli
@@ -1178,8 +1178,9 @@ vm_delete_maybe() {
             die 1 "${underline}Existing VM Check Result:${nounderline} '--import-only' option was set to 'gateway', but it already exists and '--destroy-existing-guest' option was not set."
           elif [ "${workstation_exists}" = "1" ] && [ "${import_only}" = "workstation" ] ; then
             die 1 "${underline}Existing VM Check Result:${nounderline} '--import-only' option was set to 'workstation', but it already exists and '--destroy-existing-guest' option was not set."
+          elif [ "${import_only}" = "both" ] && [ "${gateway_exists}" = "1" ] && [ "${workstation_exists}" = "1" ]; then
+            die 1 "${underline}Existing VM Check Result:${nounderline} '--import-only' option was set to 'both', but both VMs already exist and '--destroy-existing-guest' option was not set."
           fi
-        ## FIXME: Shouldn't import_only=both be handled here?
         else
           log info "Existing VM Check: Neither '--destroy-existing-guest' nor '--import-only' option was set, ok."
         fi

--- a/usr/bin/dist-installer-cli
+++ b/usr/bin/dist-installer-cli
@@ -1643,6 +1643,26 @@ get_pattern_sources_deb822_debian() {
     fi
   done < "${file}"
 
+  ## Check the last stanza in case the file does not end with an empty line.
+  match_hit='yes'
+  if [ -n "${types_pattern}" ] \
+    && ! [[ "${current_types}" =~ ${types_pattern} ]]; then
+    match_hit='no'
+  elif [ -n "${uris_pattern}" ] \
+    && ! [[ "${current_uris}" =~ ${uris_pattern} ]]; then
+    match_hit='no'
+  elif [ -n "${suites_pattern}" ] \
+    && ! [[ "${current_suites}" =~ ${suites_pattern} ]]; then
+    match_hit='no'
+  elif [ -n "${components_pattern}" ] \
+    && ! [[ "${current_components}" =~ ${components_pattern} ]]; then
+    match_hit='no'
+  fi
+
+  if [ "${match_hit}" = 'yes' ]; then
+    return 0
+  fi
+
   return 1
 }
 
@@ -1931,7 +1951,7 @@ If that doesn't resolve the issue, consider reaching out to your operating syste
 
 
 add_user_to_vbox_group() {
-  if id --name --groups "${id_of_user}" | grep -w -- "${virtualbox_linux_user_group}\$" >/dev/null; then
+  if id --name --groups "${id_of_user}" | grep -w -- "${virtualbox_linux_user_group}" >/dev/null; then
     log info "Linux Group Configuration: Account '${id_of_user}' is already a member of the Linux group 'vboxusers'."
     return 0
   fi

--- a/usr/bin/dist-installer-cli
+++ b/usr/bin/dist-installer-cli
@@ -1917,7 +1917,8 @@ If that doesn't resolve the issue, consider reaching out to your operating syste
     #install_pkg torsocks
   #fi
 
-  install_signify signify-openbsd torsocks
+  install_signify signify-openbsd
+  install_pkg torsocks
 }
 
 
@@ -4039,7 +4040,6 @@ User Options:
  -h, --help          Show this help message and exit.
 
 Developer options:
- --no-show-errors    Suppress error messages.
  --allow-errors      Continue execution despite errors. Dirty mode. Use with caution.
  --mirror=<number>   Choose a download mirror by index. Defaults to mirror 0 for
                        clearnet and mirror 0 for onion if unspecified.
@@ -4497,7 +4497,7 @@ Reboot into sysmaint session and rerun this installer."
     else
       local log_entries
       log_entries=( "${log_dir_main}"/* )
-      last_run_integer="$(printf '%s\0' "${log_entries[@]}" | sort -zrn | tr '\0' '\n' | head --lines=1)" || true
+      last_run_integer="$(printf '%s\n' "${log_entries[@]##*/}" | sort -rn | head --lines=1)" || true
       if [ -z "${last_run_integer}" ] \
         || ! is_whole_number "${last_run_integer}"; then
         last_run_integer='1'

--- a/usr/share/bash-completion/completions/dist-installer-cli
+++ b/usr/share/bash-completion/completions/dist-installer-cli
@@ -15,7 +15,7 @@ _dist_installer_cli()
         --guest-version | --socks-proxy | --onion | --non-interactive | \
             --no-import | --no-boot | --redownload | \
             --destroy-existing-guest | --dev | --ci | --dry-run | \
-            --getopt | --no-show-errors | --allow-errors | --testers | \
+            --getopt | --allow-errors | --testers | \
             --noupdate | --noupgrade | --virtualbox-only | --oracle-repo | \
             --version | --help )
             return

--- a/usr/share/usability-misc/build-dist-installer-cli
+++ b/usr/share/usability-misc/build-dist-installer-cli
@@ -55,6 +55,7 @@ helper_path="/usr/libexec/helper-scripts/"
 
 if ! test -d "$helper_path" ; then
   echo "$0: ERROR: directory helper_path '$helper_path' does not exist!" >&2
+  exit 1
 fi
 
 cp -- "${template}" "${target}"

--- a/usr/share/zsh/vendor-completions/_dist-installer-cli
+++ b/usr/share/zsh/vendor-completions/_dist-installer-cli
@@ -28,7 +28,6 @@ args=(
   '(--destroy-existing-guest)'--destroy-existing-guest'[Delete and re-import. Danger! Risk of data loss!]'
   '(-n --non-interactive)'{-n,--non-interactive}'[Set non-interactive mode]'
   '(--allow-errors)'--allow-errors'[Set dirty mode]'
-  '(--no-show-errors)'--no-show-errors'[Hide errors]'
   '(--testers)'--testers'[Set testers mode]'
   '(-D --dev)'{-D,--dev}'[Set dev mode]'
   '(--noupdate)'--noupdate'[Skip package manager list update (dev only)]'


### PR DESCRIPTION
## Summary
This PR addresses multiple bugs and improvements in the dist-installer-cli script, including fixes for VM import logic, variable assignments, string matching, and documentation updates.

## Key Changes

### VM Import and Deletion Logic
- Added handling for `--import-only=both` option to check if both gateway and workstation VMs already exist before attempting import
- Removed FIXME comment that was addressed by the above change
- Added early return in `check_vm_running_general()` for virtualbox-only and KVM hypervisor modes to skip unnecessary VM checks

### Bug Fixes
- Fixed incorrect variable assignments in `get_download_links()`: swapped `site_clearnet` and `site_onion` assignments for Kicksecure (were reversed)
- Fixed log message in `import_guest()`: changed `'--import-only'` to `'--no-import'` to match the actual option being checked
- Fixed missing closing quote in `check_hash()` log message
- Fixed regex anchor in `add_user_to_vbox_group()`: removed unnecessary `\$` escape sequence from grep pattern
- Fixed path construction in `log_term_and_file()`: changed `/${temp_folder}` to `${temp_folder}` to avoid double slashes
- Fixed log entry sorting in installer main logic: replaced null-delimited sort with newline-delimited approach for better compatibility

### Package Installation
- Separated `install_signify` and `install_pkg torsocks` into two distinct function calls instead of combining them

### File Processing
- Added logic to `get_pattern_sources_deb822_debian()` to check the last stanza in case the file doesn't end with an empty line, preventing missed matches

### Documentation and Help Text
- Updated help text to include `both` as an option for `--import-only` parameter
- Removed `--no-show-errors` option from help text and bash/zsh completions (option no longer exists)
- Fixed man page description: changed "below the specified level" to "at or above the specified level" for log-level documentation
- Fixed man page typo: changed `--noupgrade` to `--noupdate`
- Removed `--no-show-errors` from zsh completion definitions

### Build Script
- Added missing `exit 1` statement in build script error handling when helper_path directory doesn't exist

https://claude.ai/code/session_01GD1tL2UN9BxWya2mz812cc