### PR TITLE
ci: cap every job at 10 minutes

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -9,6 +9,7 @@ on:
 jobs:
     changes:
         runs-on: ubuntu-22.04
+        timeout-minutes: 10
         permissions:
             pull-requests: read
         outputs:
@@ -34,6 +35,7 @@ jobs:
         ## why we set it manually.
         ##  https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
         runs-on: ubuntu-24.04
+        timeout-minutes: 10
         strategy:
             fail-fast: false
             #fail-fast: true


### PR DESCRIPTION
Add timeout-minutes: 10 to all jobs so runaway CI steps fail fast instead of consuming the default 360-minute budget.

This pull request changes...

## Changes

## Mandatory Checklist

- [ ] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
