### PR TITLE
console-setup: only run when a framebuffer exists (skip serial/headless)

### DIFF
--- a/usr/lib/systemd/system/console-setup.service.d/30_fix.conf
+++ b/usr/lib/systemd/system/console-setup.service.d/30_fix.conf
@@ -4,3 +4,9 @@
 
 [Unit]
 After=systemd-tmpfiles-setup.service
+
+## Only run console font/keymap setup when a framebuffer console exists. On a headless or
+## serial-only boot (no GPU, hence no /dev/fb0) setupcon's setfont cannot work and spams
+## 'setfont: ERROR ioctl(KDFONTOP): Invalid argument' repeatedly. Gating on /dev/fb0 skips the
+## service cleanly there (a normal graphical boot has /dev/fb0, so it is unaffected).
+ConditionPathExists=/dev/fb0


### PR DESCRIPTION
On a headless or serial-only boot (no GPU, hence no `/dev/fb0`) `setupcon`'s `setfont` cannot work and spams `setfont: ERROR ioctl(KDFONTOP): Invalid argument` repeatedly in the journal. This gates the existing console-setup.service drop-in on `ConditionPathExists=/dev/fb0`, so it is skipped cleanly there; a normal graphical boot has `/dev/fb0` and is unaffected.

Found via `systemcheck --leak-tests` headless in qemu. Not yet runtime-validated on a rebuilt image.

AI-Assisted.